### PR TITLE
Skip SDA if the card doesn't support it

### DIFF
--- a/emv/dataAuthentication.js
+++ b/emv/dataAuthentication.js
@@ -177,6 +177,11 @@ DataAuthentication.prototype.retrieveIssuerPublicKey = function() {
  * @param {Key} key the Issuer Public Key
 */
 DataAuthentication.prototype.verifySSAD = function(issuerPublicKeyModulus) {
+	var SSAD = this.emv.cardDE[0x93];
+	if (typeof(SSAD) == "undefined") {
+		print("<-----------------------------SDA is not supported on this card------------------------------>\n");
+		return;
+	}
 	var issuerPublicKeyModulus =  issuerPublicKeyModulus;
 	var key = new Key();
 	key.setType(Key.PUBLIC);


### PR DESCRIPTION
Modern cards don't contain 0x93, so SDA is not possible.